### PR TITLE
FEAT: 프로젝트 등록 시 실시간 알림

### DIFF
--- a/http-test/auth.http
+++ b/http-test/auth.http
@@ -3,7 +3,7 @@ POST {{host}}/api/v1/auth/login
 Content-Type: application/json
 
 {
-  "id": "test",
+  "id": "test2",
   "password": "password123"
 }
 

--- a/http-test/notification.http
+++ b/http-test/notification.http
@@ -1,0 +1,14 @@
+### 알림 확인
+GET http://localhost:8080/api/v1/notifications
+Content-Type: application/json
+Authorization: Bearer {{accessToken}}
+
+### 알림 읽음 처리
+PUT http://localhost:8080/api/v1/notifications/1
+Content-Type: application/json
+Authorization: Bearer {{accessToken}}
+
+### 알림 삭제
+DELETE http://localhost:8080/api/v1/notifications/1
+Content-Type: application/json
+Authorization: Bearer {{accessToken}}

--- a/http-test/team-recruit.http
+++ b/http-test/team-recruit.http
@@ -6,7 +6,7 @@ Authorization: Bearer {{accessToken}}
 {
   "title": "사이드 프로젝트 팀원 모집합니다",
   "content": "백엔드 개발자 2명 모집합니다",
-  "techStacks": ["JAVA", "SPRING", "MYSQL"],
+  "techStacks": ["JAVA", "SPRING", "MYSQL", "PYTHON"],
   "expectedPeriod": "3개월",
   "fileUrl": "http://example.com/file",
   "contact": "kakao: example"

--- a/src/main/java/com/example/sideproject/domain/team/service/TeamRecruitNoticeService.java
+++ b/src/main/java/com/example/sideproject/domain/team/service/TeamRecruitNoticeService.java
@@ -1,0 +1,46 @@
+package com.example.sideproject.domain.team.service;
+
+import com.example.sideproject.domain.team.entity.TeamRecruit;
+import com.example.sideproject.domain.user.entity.TechStack;
+import com.example.sideproject.domain.user.entity.User;
+import com.example.sideproject.global.notification.aop.annotation.NotifyOn;
+import com.example.sideproject.global.notification.dto.EventDto;
+import com.example.sideproject.global.notification.dto.EventListDto;
+import com.example.sideproject.global.notification.entity.NotificationType;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+public class TeamRecruitNoticeService {
+
+    @NotifyOn
+    public EventListDto notice(TeamRecruit recruit, List<User> users, Set<TechStack> techStacks) {
+        String msg = "\'" + recruit.getTitle() + "\' 가 등록되었습니다.";
+        return new EventListDto(users.stream()
+                .map(user -> new EventDto(
+                        user.getId(),
+                        recruit.getUser().getId(),
+                        findFitTechStacks(user.getTechStacks(), techStacks) + " $| " + msg,
+                        NotificationType.PROJECT_REGISTRATION,
+                        "/api/v1/team-recruit/" + recruit.getId())
+                ).toList()
+        );
+    }
+
+
+    /**
+     *
+     * @param reqStacks
+     * @param myStacks
+     * @return
+     */
+    private String findFitTechStacks(Set<TechStack> reqStacks, Set<TechStack> myStacks) {
+        return reqStacks.stream()
+                .filter(myStacks::contains)
+                .map(TechStack::getDisplayName)
+                .collect(Collectors.joining(","));
+    }
+}

--- a/src/main/java/com/example/sideproject/domain/team/service/TeamRecruitService.java
+++ b/src/main/java/com/example/sideproject/domain/team/service/TeamRecruitService.java
@@ -3,6 +3,9 @@ package com.example.sideproject.domain.team.service;
 import com.example.sideproject.domain.team.dto.CreateTeamRecruitRequestDto;
 import com.example.sideproject.domain.team.dto.CreateTeamRecruitResponseDto;
 import com.example.sideproject.domain.team.dto.CreateTeamRecruitPageResponseDto;
+import com.example.sideproject.global.notification.aop.annotation.NotifyOn;
+import com.example.sideproject.global.notification.dto.EventDto;
+import com.example.sideproject.global.notification.entity.NotificationType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +18,7 @@ import com.example.sideproject.global.enums.ErrorType;
 import com.example.sideproject.domain.team.repository.TeamRecruitRepository;
 import java.util.Objects;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
@@ -29,6 +33,7 @@ import org.springframework.data.domain.Sort;
 public class TeamRecruitService {
     private final UserRepository userRepository;
     private final TeamRecruitRepository teamRecruitRepository;
+    private final TeamRecruitNoticeService teamRecruitNoticeService;
 
     @Transactional
     public void createTeamRecruit(CreateTeamRecruitRequestDto requestDto, User user) {
@@ -45,7 +50,15 @@ public class TeamRecruitService {
         );
 
         teamRecruitRepository.save(teamRecruit);
+
+        List<User> users = findUserByTechStacks(teamRecruit.getTechStacks());
+        teamRecruitNoticeService.notice(teamRecruit, users, requestDto.getTechStacks());
     }
+
+    private List<User> findUserByTechStacks(Set<TechStack> techStacks) {
+        return userRepository.findByTechStacksIn(techStacks);
+    }
+
 
     public CreateTeamRecruitResponseDto getTeamRecruit(Long teamRecruitId) {
         TeamRecruit teamRecruit = findTeamRecruit(teamRecruitId);

--- a/src/main/java/com/example/sideproject/domain/user/entity/TechStack.java
+++ b/src/main/java/com/example/sideproject/domain/user/entity/TechStack.java
@@ -30,4 +30,8 @@ public enum TechStack {
         this.displayName = displayName;
         this.iconClass = iconClass;
     }
+
+    public String getDisplayName() {
+        return displayName;
+    }
 }

--- a/src/main/java/com/example/sideproject/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/sideproject/domain/user/repository/UserRepository.java
@@ -1,9 +1,12 @@
 package com.example.sideproject.domain.user.repository;
 
+import com.example.sideproject.domain.user.entity.TechStack;
 import com.example.sideproject.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
@@ -15,4 +18,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
 
     Optional<User> findByRefreshToken(String refreshToken);
+
+    List<User> findByTechStacksIn(Set<TechStack> techStacks);
 }

--- a/src/main/java/com/example/sideproject/global/notification/aop/NotificationAspect.java
+++ b/src/main/java/com/example/sideproject/global/notification/aop/NotificationAspect.java
@@ -2,12 +2,15 @@ package com.example.sideproject.global.notification.aop;
 
 import com.example.sideproject.global.notification.aop.annotation.NotifyOn;
 import com.example.sideproject.global.notification.dto.EventDto;
+import com.example.sideproject.global.notification.dto.EventListDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.annotation.AfterReturning;
 import org.aspectj.lang.annotation.Aspect;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Slf4j
 @Component
@@ -17,7 +20,7 @@ public class NotificationAspect {
     private final ApplicationEventPublisher publisher;
 
     @AfterReturning(pointcut = "@annotation(annotation)", returning = "res")
-    public void publish(EventDto res, NotifyOn annotation) {
+    public void publish(EventListDto res, NotifyOn annotation) {
         log.info("이벤트 발행");
         publisher.publishEvent(res);
     }

--- a/src/main/java/com/example/sideproject/global/notification/controller/NotificationController.java
+++ b/src/main/java/com/example/sideproject/global/notification/controller/NotificationController.java
@@ -2,14 +2,11 @@ package com.example.sideproject.global.notification.controller;
 
 import com.example.sideproject.global.notification.dto.NotificationDto;
 import com.example.sideproject.global.notification.service.NotificationService;
-import com.example.sideproject.global.notification.service.SseService;
 import com.example.sideproject.global.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.List;
 
@@ -25,9 +22,9 @@ public class NotificationController {
     }
 
     @PutMapping("/{notificationId}")
-    public ResponseEntity<NotificationDto> updateNotification(@AuthenticationPrincipal UserDetailsImpl userDetails,
-                                                              @PathVariable("notificationId") Long notificationId) {
-        return ResponseEntity.ok(notificationService.updateNotification(notificationId, userDetails.getUser()));
+    public ResponseEntity<NotificationDto> readNotification(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                            @PathVariable("notificationId") Long notificationId) {
+        return ResponseEntity.ok(notificationService.readNotification(notificationId, userDetails.getUser()));
     }
 
     @DeleteMapping("/{notificationId}")

--- a/src/main/java/com/example/sideproject/global/notification/controller/SseController.java
+++ b/src/main/java/com/example/sideproject/global/notification/controller/SseController.java
@@ -17,8 +17,8 @@ public class SseController {
     private final SseService sseService;
 
     @GetMapping(produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public ResponseEntity<SseEmitter> connect(@AuthenticationPrincipal UserDetailsImpl userDetails) {
-        return ResponseEntity.ok(sseService.connect(userDetails.getUser().getId()));
+    public SseEmitter connect(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return sseService.connect(userDetails.getUser().getId());
     }
 
     @DeleteMapping

--- a/src/main/java/com/example/sideproject/global/notification/dto/EventListDto.java
+++ b/src/main/java/com/example/sideproject/global/notification/dto/EventListDto.java
@@ -3,12 +3,10 @@ package com.example.sideproject.global.notification.dto;
 import com.example.sideproject.global.notification.entity.NotificationType;
 import lombok.Builder;
 
+import java.util.List;
+
 @Builder
-public record EventDto(
-        Long to,
-        Long from,
-        String msg,
-        NotificationType type,
-        String relatedUrl
+public record EventListDto(
+        List<EventDto> eventDtos
 ) {
 }

--- a/src/main/java/com/example/sideproject/global/notification/dto/NotificationRequestDto.java
+++ b/src/main/java/com/example/sideproject/global/notification/dto/NotificationRequestDto.java
@@ -21,4 +21,13 @@ public record NotificationRequestDto(
                 .relatedUrl(relatedUrl)
                 .build();
     }
+
+    public static NotificationRequestDto of(EventDto eventDto) {
+        return NotificationRequestDto.builder()
+                .to(eventDto.to())
+                .type(eventDto.type())
+                .message(eventDto.msg())
+                .relatedUrl(eventDto.relatedUrl())
+                .build();
+    }
 }

--- a/src/main/java/com/example/sideproject/global/notification/entity/Notification.java
+++ b/src/main/java/com/example/sideproject/global/notification/entity/Notification.java
@@ -26,7 +26,6 @@ public class Notification {
     private String relatedUrl;
 
     @ColumnDefault("false")
-    @Column(columnDefinition = "TINYINT(1)")
     private boolean isRead;
 
     @Builder

--- a/src/main/java/com/example/sideproject/global/notification/entity/NotificationType.java
+++ b/src/main/java/com/example/sideproject/global/notification/entity/NotificationType.java
@@ -1,5 +1,5 @@
 package com.example.sideproject.global.notification.entity;
 
 public enum NotificationType {
-    PROJECT_REGISTRATION, TEAM_LEADER_NOTIFICATION
+    CONNECT, PROJECT_REGISTRATION, TEAM_LEADER_NOTIFICATION
 }

--- a/src/main/java/com/example/sideproject/global/notification/service/EventService.java
+++ b/src/main/java/com/example/sideproject/global/notification/service/EventService.java
@@ -11,6 +11,7 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Objects;
 
 @Slf4j
 @Service
@@ -19,18 +20,36 @@ public class EventService {
     private final SseService sseService;
     private final NotificationService notificationService;
 
+    /**
+     * sse로 알림 데이터 전송
+     * @param listDto 알림 리스트
+     */
     @EventListener
     public void send(EventListDto listDto) {
-        listDto.eventDtos().forEach(sseService::send);
+        filterEvents(listDto).forEach(sseService::send);
     }
 
+    /**
+     * 알림 데이터를 데이터베이스에 저장한다.
+     * @param listDto 알림 리스트
+     */
     @Async("taskExecutor")
     @EventListener
     public void save(EventListDto listDto) {
-        listDto.eventDtos().forEach(eventDto -> {
+        filterEvents(listDto).forEach(eventDto -> {
             NotificationRequestDto requestDto = NotificationRequestDto.of(eventDto);
             notificationService.createNotification(requestDto, new User(eventDto.from()));
         });
     }
 
+    /**
+     * 본인에게는 알림이 안가도록 필터링
+      * @param listDto 알림 리스트
+     * @return 본인 제외한 알림 리스트
+     */
+    private List<EventDto> filterEvents(EventListDto listDto) {
+        return listDto.eventDtos().stream()
+                .filter(event -> !Objects.equals(event.from(), event.to()))
+                .toList();
+    }
 }

--- a/src/main/java/com/example/sideproject/global/notification/service/EventService.java
+++ b/src/main/java/com/example/sideproject/global/notification/service/EventService.java
@@ -2,12 +2,15 @@ package com.example.sideproject.global.notification.service;
 
 import com.example.sideproject.domain.user.entity.User;
 import com.example.sideproject.global.notification.dto.EventDto;
+import com.example.sideproject.global.notification.dto.EventListDto;
 import com.example.sideproject.global.notification.dto.NotificationRequestDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Slf4j
 @Service
@@ -17,20 +20,17 @@ public class EventService {
     private final NotificationService notificationService;
 
     @EventListener
-    public void send(EventDto eventDto) {
-        sseService.send(eventDto);
+    public void send(EventListDto listDto) {
+        listDto.eventDtos().forEach(sseService::send);
     }
 
     @Async("taskExecutor")
     @EventListener
-    public void save(EventDto eventDto) {
-        NotificationRequestDto requestDto = NotificationRequestDto.builder()
-                .to(eventDto.to())
-                .type(eventDto.type())
-                .message(eventDto.msg())
-                .relatedUrl(eventDto.relatedUrl())
-                .build();
-
-        notificationService.createNotification(requestDto, new User(eventDto.from()));
+    public void save(EventListDto listDto) {
+        listDto.eventDtos().forEach(eventDto -> {
+            NotificationRequestDto requestDto = NotificationRequestDto.of(eventDto);
+            notificationService.createNotification(requestDto, new User(eventDto.from()));
+        });
     }
+
 }

--- a/src/main/java/com/example/sideproject/global/notification/service/NotificationService.java
+++ b/src/main/java/com/example/sideproject/global/notification/service/NotificationService.java
@@ -25,7 +25,7 @@ public class NotificationService {
     }
 
     @Transactional
-    public NotificationDto updateNotification(Long notificationId, User user) {
+    public NotificationDto readNotification(Long notificationId, User user) {
         Notification notification = getNotification(notificationId);
         notification.read(user.getId());
         return NotificationDto.of(notification);

--- a/src/main/java/com/example/sideproject/global/notification/service/SseService.java
+++ b/src/main/java/com/example/sideproject/global/notification/service/SseService.java
@@ -18,20 +18,26 @@ public class SseService {
     private final EmitterRepository emitterRepository;
 
     public SseEmitter connect(Long userId) {
-        log.info("{} 알림 서비스 접속", userId);
+        log.debug("{} 알림 서비스 접속", userId);
         return emitterRepository.connect(userId);
     }
 
     public void send(EventDto eventDto) {
-        log.info("{}에게 알람 전송을 시작합니다.", eventDto.to());
         SseEmitter session = emitterRepository.getSession(eventDto.to())
-                .orElseThrow(RuntimeException::new);
+                .orElse(null);
+
+        if (session == null) {
+            return;
+        }
+
+        log.debug("{}에게 알람 전송을 시작합니다.", eventDto.to());
+
         try {
             session.send(SseEmitter.event()
                     .data(eventDto)
                     .build());
         } catch (IOException e) {
-            log.info("알림 메시지 전송 중 오류가 발생했습니다.");
+            log.debug("알림 메시지 전송 중 오류가 발생했습니다.");
             throw new RuntimeException(e);
         }
     }

--- a/src/test/java/com/example/sideproject/global/notification/service/EventServiceTest.java
+++ b/src/test/java/com/example/sideproject/global/notification/service/EventServiceTest.java
@@ -2,11 +2,14 @@ package com.example.sideproject.global.notification.service;
 
 import com.example.sideproject.global.notification.aop.annotation.NotifyOn;
 import com.example.sideproject.global.notification.dto.EventDto;
+import com.example.sideproject.global.notification.dto.EventListDto;
 import com.example.sideproject.global.notification.entity.NotificationType;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @SpringBootTest
 class EventServiceTest {
@@ -29,17 +32,20 @@ class EventServiceTest {
 
         Thread.sleep(1000);
     }
+
 }
 
 @Component
 class EventPushTest {
     @NotifyOn
-    public EventDto subscribe() {
-        return EventDto.builder()
-                .to(1L)
-                .from(1L)
-                .msg("1에게 메시지 전달")
-                .type(NotificationType.PROJECT_REGISTRATION)
-                .build();
+    public EventListDto subscribe() {
+        return new EventListDto(List.of(
+                EventDto.builder()
+                        .to(1L)
+                        .from(1L)
+                        .msg("1에게 메시지 전달")
+                        .type(NotificationType.PROJECT_REGISTRATION)
+                        .build()
+        ));
     }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,9 +1,9 @@
 spring:
   datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/sideproject
-    username: user
-    password: user
+    driver-class-name: org.postgresql.Driver
+    url: ${DB_URL}
+    username: ${DB_USER}
+    password: ${DB_PASSWORD}
 
   jpa:
     hibernate:
@@ -12,7 +12,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
-        dialect: org.hibernate.dialect.MySQLDialect
-jwt:
-  secret:
-    key: c3ByaW5nLWJvb3Qtc2VjdXJpdHktand0LXR1dG9yaWFsLWppd29vbi1zcHJpbmctYm9vdC1zZWN1cml0eS1qd3QtdHV0b3JpYWwK
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+  jwt:
+    secret:
+      key: ${JWT_SECRET_KEY}


### PR DESCRIPTION
## 추가 기능
* 프로젝트 등록 시 회원 정보에 저장된 기술 스택 조회 후 실시간 알림
* 등록한 본인에게는 수신하지 않음
* sse timeout은 5분으로 설정
* sse 접속 시 connect 메시지 전송
* `$|`를 구분자로 두어 유저와 해당하는 기술 스택과 메시지 구분

## 테스트 결과
유저 4 -> 1에게 메시지 전송
![image](https://github.com/user-attachments/assets/59923217-fdf9-4db0-bbb3-6012eab55ffc)

유저 4 -> 5에게 메시지 전송
![image](https://github.com/user-attachments/assets/b00f1985-6bf7-4a03-a5fa-5846d3722385)
