### PR TITLE
[FEAT]: 이력서 프로젝트 경험- 프로젝트 기간 시작, 종료날짜 나누어 받도록 수정

### DIFF
--- a/http-test/resume.http
+++ b/http-test/resume.http
@@ -15,7 +15,8 @@ Authorization: Bearer {{accessToken}}
     "achievement": "React와 TypeScript를 활용한 대규모 커머스 플랫폼의 프론트엔드 개발을 담당했습니다. 성능 최적화와 사용자 경험 개선에 주력하여 페이지 로딩 속도를 40% 개선했습니다.",
     "teamSize": 2,
     "documentUrl": "https://experience1",
-    "period": "2025.01.02~2025.01.22"
+    "startDate": "2025-02-05T13:53:31",
+    "endDate": "2025-03-07T13:53:31"
   }]
 }
 
@@ -25,7 +26,7 @@ Content-Type: application/json
 Authorization: Bearer {{accessToken}}
 
 ### 이력 수정
-PUT {{host}}/api/v1/resume/5
+PUT {{host}}/api/v1/resume/1
 Content-Type: application/json
 Authorization: Bearer {{accessToken}}
 
@@ -42,13 +43,15 @@ Authorization: Bearer {{accessToken}}
       "achievement": "React와 TypeScript를 활용한 대규모 커머스 플랫폼의 프론트엔드 개발을 담당했습니다. 성능 최적화와 사용자 경험 개선에 주력하여 페이지 로딩 속도를 40% 개선했습니다.",
       "teamSize": 2,
       "documentUrl": "https://experience1",
-      "period": "2025.01.02~2025.01.22"
+      "startDate": "2024-01-05T13:53:11",
+      "endDate": "2024-12-07T13:53:31"
     },{
       "title": "실시간 데이터 대시보드 시스템 구축",
       "achievement": "실시간 데이터를 시각화하는 대시보드 시스템을 개발했습니다. WebSocket을 활용한 실시간 데이터 처리와 차트 컴포넌트 최적화를 진행했습니다.",
       "teamSize": 1,
       "documentUrl": "https://dashboard",
-      "period": "2024.01.02"
+      "startDate": "2024-02-05T13:53:31",
+      "endDate": "2024-03-07T13:53:31"
     }]
 }
 

--- a/src/main/java/com/example/sideproject/domain/resume/controller/ResumeController.java
+++ b/src/main/java/com/example/sideproject/domain/resume/controller/ResumeController.java
@@ -9,6 +9,7 @@ import com.example.sideproject.global.enums.ResponseStatus;
 import com.example.sideproject.global.security.UserDetailsImpl;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -30,7 +31,7 @@ public class ResumeController {
     @Operation(summary = "이력서 저장", description = "이력서를 저장한다.")
     @PostMapping
     public ResponseEntity<ResponseDataDto<Long>> saveResume(@AuthenticationPrincipal UserDetailsImpl userDetails,
-                                                            @RequestBody ResumeRequestDto req) {
+                                                            @RequestBody @Valid ResumeRequestDto req) {
         return ResponseEntity.ok(new ResponseDataDto<>(ResponseStatus.SUCCESS, resumeService.saveResume(userDetails.getUser(), req)));
     }
 
@@ -38,7 +39,7 @@ public class ResumeController {
     @PutMapping("/{resumeId}")
     public ResponseEntity<ResponseMessageDto> updateResume(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                            @PathVariable("resumeId") Long resumeId,
-                                                           @RequestBody ResumeRequestDto req) {
+                                                           @RequestBody @Valid ResumeRequestDto req) {
         resumeService.updateResume(userDetails.getUser(), resumeId, req);
         return ResponseEntity.ok(new ResponseMessageDto(ResponseStatus.SUCCESS));
     }

--- a/src/main/java/com/example/sideproject/domain/resume/dto/ExperienceRequestDto.java
+++ b/src/main/java/com/example/sideproject/domain/resume/dto/ExperienceRequestDto.java
@@ -1,21 +1,41 @@
 package com.example.sideproject.domain.resume.dto;
 
 import com.example.sideproject.domain.resume.entity.Experience;
+import com.example.sideproject.global.validation.time.ValidLocalDateTime;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 public record ExperienceRequestDto(
+        @Schema(description = "제목")
         String title,
-        String period,
+        @Schema(description = "시작 날짜, yyyy-MM-dd'T'HH:mm:ss 형식 값")
+        @ValidLocalDateTime
+        String startDate,
+        @Schema(description = "종료 날짜, yyyy-MM-dd'T'HH:mm:ss 형식 값")
+        @ValidLocalDateTime
+        String endDate,
+        @Schema(description = "참여 인원")
         int teamSize,
+        @Schema(description = "담당 업무 및 성과")
         String achievement,
+        @Schema(description = "프로젝트 링크")
         String documentUrl
 ) {
     public Experience toEntity() {
         return Experience.builder()
                 .title(title)
-                .period(period)
+                .startDate(getLocalDateTime(startDate))
+                .endDate(getLocalDateTime(endDate))
                 .teamSize(teamSize)
                 .achievement(achievement)
                 .documentUrl(documentUrl)
                 .build();
+    }
+
+    private LocalDateTime getLocalDateTime(String str) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+        return LocalDateTime.parse(str, formatter);
     }
 }

--- a/src/main/java/com/example/sideproject/domain/resume/dto/ExperienceResponseDto.java
+++ b/src/main/java/com/example/sideproject/domain/resume/dto/ExperienceResponseDto.java
@@ -3,11 +3,14 @@ package com.example.sideproject.domain.resume.dto;
 import com.example.sideproject.domain.resume.entity.Experience;
 import lombok.Builder;
 
+import java.time.LocalDateTime;
+
 @Builder
 public record ExperienceResponseDto(
         Long experienceId,
         String title,
-        String period,
+        LocalDateTime startDate,
+        LocalDateTime endDate,
         int teamSize,
         String achievement,
         String documentUrl
@@ -16,7 +19,8 @@ public record ExperienceResponseDto(
         return ExperienceResponseDto.builder()
                 .experienceId(experience.getId())
                 .title(experience.getTitle())
-                .period(experience.getPeriod())
+                .startDate(experience.getStartDate())
+                .endDate(experience.getEndDate())
                 .teamSize(experience.getTeamSize())
                 .achievement(experience.getAchievement())
                 .documentUrl(experience.getDocumentUrl())

--- a/src/main/java/com/example/sideproject/domain/resume/dto/ResumeRequestDto.java
+++ b/src/main/java/com/example/sideproject/domain/resume/dto/ResumeRequestDto.java
@@ -4,18 +4,27 @@ import com.example.sideproject.domain.resume.entity.Resume;
 import com.example.sideproject.domain.techstack.entity.TechStack;
 import com.example.sideproject.domain.user.entity.User;
 import com.example.sideproject.global.enums.WorkType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 
 import java.util.HashSet;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public record ResumeRequestDto(
+        @Schema(description = "직무")
         String position,
+        @Schema(description = "이력서 제목")
         String title,
+        @Schema(description = "자기 소개")
         String introduce,
+        @Schema(description = "희망 진행 방식")
         WorkType workType,
+        @Schema(description = "이력서 링크")
         List<String> documentUrl,
+        @Schema(description = "기술 스택 ID 리스트")
         List<Long> techStackIds,
+        @Schema(description = "프로젝트 리스트")
+        @Valid
         List<ExperienceRequestDto> experiences
 ) {
     public ResumeRequestDto {

--- a/src/main/java/com/example/sideproject/domain/resume/entity/Experience.java
+++ b/src/main/java/com/example/sideproject/domain/resume/entity/Experience.java
@@ -4,6 +4,8 @@ import com.example.sideproject.global.entity.Timestamped;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
@@ -21,12 +23,14 @@ public class Experience extends Timestamped {
 
     private String title;
 
-    private String period;
-
     private int teamSize;
 
     @Column(columnDefinition = "TEXT")
     private String achievement;
+
+    private LocalDateTime startDate;
+
+    private LocalDateTime endDate;
 
     private String documentUrl;
 
@@ -36,7 +40,8 @@ public class Experience extends Timestamped {
 
     public void update(Experience experience) {
         this.title = experience.title;
-        this.period = experience.period;
+        this.startDate = experience.startDate;
+        this.endDate = experience.endDate;
         this.teamSize = experience.teamSize;
         this.achievement = experience.achievement;
         this.documentUrl = experience.documentUrl;

--- a/src/main/java/com/example/sideproject/global/validation/time/ValidLocalDateTime.java
+++ b/src/main/java/com/example/sideproject/global/validation/time/ValidLocalDateTime.java
@@ -1,0 +1,18 @@
+package com.example.sideproject.global.validation.time;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = ValidLocalDateTimeValidator.class)
+public @interface ValidLocalDateTime {
+    String message() default "yyyy-MM-dd'T'HH:mm:ss 형식이 아닙니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/example/sideproject/global/validation/time/ValidLocalDateTimeValidator.java
+++ b/src/main/java/com/example/sideproject/global/validation/time/ValidLocalDateTimeValidator.java
@@ -1,0 +1,27 @@
+package com.example.sideproject.global.validation.time;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class ValidLocalDateTimeValidator implements ConstraintValidator<ValidLocalDateTime, String> {
+
+    @Override
+    public boolean isValid(String s, ConstraintValidatorContext constraintValidatorContext) {
+        if (s == null) {
+            return true;
+        }
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+
+        try {
+            LocalDateTime.parse(s, formatter);
+        } catch (Exception e) {
+            return false;
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
# 설명
## AS-IS
- 프로젝트 기간을 string으로 받음

## TO-BE
- 시작, 종료날짜 필드를 추가하여 `yyyy-MM-dd'T'HH:mm:ss` 형식의 String 으로 받도록 수정