### PR TITLE
[FIX] pr 조회 시 기술스택 없을 때 빈 배열 리턴하도록 수정

### DIFF
--- a/http-test/pr.http
+++ b/http-test/pr.http
@@ -18,16 +18,20 @@ Authorization: Bearer {{accessToken}}
     "teamSize": 5
   }],
   "techStacks": [{
-    "id": 101,
+    "id": 1,
     "level": 1
   },{
-    "id": 102,
+    "id": 12,
     "level": 5
   }]
 }
 
 ### PR 게시글 리스트 조회
-GET {{host}}/api/v1/post/pr?page=0&size=20&workTypes=ALL&positions=FRONTEND,BACKEND&techStackIds=102,103&searchText=title
+GET {{host}}/api/v1/post/pr
+Content-Type: application/json
+
+### PR 게시글 리스트 조회
+GET {{host}}/api/v1/post/pr?page=0&size=20&workTypes=OFFLINE&positions=FRONTEND,BACKEND&techStackIds=1
 Content-Type: application/json
 
 ### PR 게시글 조회
@@ -35,7 +39,7 @@ GET {{host}}/api/v1/post/pr/2
 Content-Type: application/json
 
 ### PR 게시글 수정
-PUT {{host}}/api/v1/post/pr/3
+PUT {{host}}/api/v1/post/pr/2
 Content-Type: application/json
 Authorization: Bearer {{accessToken}}
 
@@ -61,10 +65,10 @@ Authorization: Bearer {{accessToken}}
     "teamSize": 1
   }],
   "techStacks": [{
-    "id": 103,
+    "id": 1,
     "level": 1
   },{
-    "id": 104,
+    "id": 16,
     "level": 10
   }]
 }

--- a/src/main/java/com/example/sideproject/domain/pr/dto/PrListResponseDto.java
+++ b/src/main/java/com/example/sideproject/domain/pr/dto/PrListResponseDto.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 
 @Getter
 public class PrListResponseDto extends PostResponseDto {
@@ -22,7 +23,7 @@ public class PrListResponseDto extends PostResponseDto {
     }
 
     public PrListResponseDto addTechStacks(List<PrTechStackResponse> techStacks) {
-        this.techStacks = techStacks;
+        this.techStacks = Objects.requireNonNullElse(techStacks, List.of());
         return this;
     }
 

--- a/src/main/java/com/example/sideproject/domain/pr/dto/PrResponse.java
+++ b/src/main/java/com/example/sideproject/domain/pr/dto/PrResponse.java
@@ -37,11 +37,11 @@ public class PrResponse extends PostResponseDto {
     }
 
     public PrResponse setTechStacks(List<PrTechStack> techStacks) {
-        this.techStacks = of(techStacks);
+        this.techStacks = toPrTechStackResponse(techStacks);
         return this;
     }
 
-    private List<PrTechStackResponse> of(List<PrTechStack> techStacks) {
+    private List<PrTechStackResponse> toPrTechStackResponse(List<PrTechStack> techStacks) {
         return techStacks.stream()
                 .map(t -> new PrTechStackResponse(
                         t.getTechStack().getId(),


### PR DESCRIPTION
# 연관
- [서버 이슈](https://www.notion.so/recruit-288b95dab55c806a846af3bab0f58d32?source=copy_link)

# 내용
- pr 조회 시 기술 스택이 없을 때 null로 리턴하던 문제 수정