### PR TITLE
[FIX] 기술스택 데이터 캐싱 방어로직 추가

### DIFF
--- a/src/main/java/com/example/sideproject/domain/techstack/service/CacheTechStackStorage.java
+++ b/src/main/java/com/example/sideproject/domain/techstack/service/CacheTechStackStorage.java
@@ -1,0 +1,10 @@
+package com.example.sideproject.domain.techstack.service;
+
+import com.example.sideproject.domain.techstack.entity.TechStack;
+
+import java.util.List;
+
+public interface CacheTechStackStorage {
+    List<TechStack> findAll();
+    void saveAll(List<TechStack> techStacks);
+}

--- a/src/main/java/com/example/sideproject/domain/techstack/service/PersistentTechStackStorage.java
+++ b/src/main/java/com/example/sideproject/domain/techstack/service/PersistentTechStackStorage.java
@@ -1,0 +1,10 @@
+package com.example.sideproject.domain.techstack.service;
+
+import com.example.sideproject.domain.techstack.entity.TechStack;
+
+import java.util.List;
+
+public interface PersistentTechStackStorage {
+    List<TechStack> findAll();
+    void saveAll(List<TechStack> techStacks);
+}

--- a/src/main/java/com/example/sideproject/domain/techstack/service/TechStackService.java
+++ b/src/main/java/com/example/sideproject/domain/techstack/service/TechStackService.java
@@ -15,23 +15,10 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class TechStackService {
-    private final TechStackRepository techStackRepository;
-//    private final TechStackCacheRepository techStackCacheRepository;
+    private final TechStackSourceManager techStackSourceManager;
 
     public List<TechStackDto> getTeckStackList(){
-//        List<TechStack> cacheTechStacks = techStackCacheRepository.findTechStack();
-
-//        if (!cacheTechStacks.isEmpty()) {
-//            return TechStackDto.of(cacheTechStacks);
-//        }
-
-        List<TechStack> techStacks = techStackRepository.findAll();
-//        for (TechStack techStack : techStacks) {
-//            techStackCacheRepository.save(techStack);
-//        }
-//
-//        List<TechStackDto> a = new ArrayList<>();
-        return TechStackDto.of(techStacks);
+        return techStackSourceManager.getTechStackList();
     }
 
 }

--- a/src/main/java/com/example/sideproject/domain/techstack/service/TechStackSourceManager.java
+++ b/src/main/java/com/example/sideproject/domain/techstack/service/TechStackSourceManager.java
@@ -1,0 +1,35 @@
+package com.example.sideproject.domain.techstack.service;
+
+import com.example.sideproject.domain.techstack.dto.TechStackDto;
+import com.example.sideproject.domain.techstack.entity.TechStack;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class TechStackSourceManager {
+    private final CacheTechStackStorage cacheStorage;
+    private final PersistentTechStackStorage databaseStorage;
+
+    public List<TechStackDto> getTechStackList() {
+        // 1. 캐시에서 조회
+        List<TechStack> cached = cacheStorage.findAll();
+        
+        if (!cached.isEmpty()) {
+            return TechStackDto.of(cached);
+        }
+        
+        // 2. 캐시 미스 - DB 조회
+        log.info("Cache miss, fetching from database");
+        List<TechStack> fromDb = databaseStorage.findAll();
+        
+        // 3. 캐시에 저장
+        cacheStorage.saveAll(fromDb);
+        
+        return TechStackDto.of(fromDb);
+    }
+}

--- a/src/main/java/com/example/sideproject/domain/techstack/service/impl/DatabaseTechStackStorage.java
+++ b/src/main/java/com/example/sideproject/domain/techstack/service/impl/DatabaseTechStackStorage.java
@@ -1,0 +1,27 @@
+package com.example.sideproject.domain.techstack.service.impl;
+
+import com.example.sideproject.domain.techstack.entity.TechStack;
+import com.example.sideproject.domain.techstack.repository.TechStackRepository;
+import com.example.sideproject.domain.techstack.service.PersistentTechStackStorage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DatabaseTechStackStorage implements PersistentTechStackStorage {
+    private final TechStackRepository techStackRepository;
+
+    @Override
+    public List<TechStack> findAll() {
+        return techStackRepository.findAll();
+    }
+
+    @Override
+    public void saveAll(List<TechStack> techStacks) {
+        techStackRepository.saveAll(techStacks);
+    }
+}

--- a/src/main/java/com/example/sideproject/domain/techstack/service/impl/RedisTechStackStorage.java
+++ b/src/main/java/com/example/sideproject/domain/techstack/service/impl/RedisTechStackStorage.java
@@ -1,0 +1,36 @@
+package com.example.sideproject.domain.techstack.service.impl;
+
+import com.example.sideproject.domain.techstack.entity.TechStack;
+import com.example.sideproject.domain.techstack.repository.TechStackCacheRepository;
+import com.example.sideproject.domain.techstack.service.CacheTechStackStorage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RedisTechStackStorage implements CacheTechStackStorage {
+    private final TechStackCacheRepository techStackCacheRepository;
+
+    @Override
+    public List<TechStack> findAll() {
+        try {
+            return techStackCacheRepository.findTechStack();
+        } catch (Exception e) {
+            log.warn("Failed to fetch from cache", e);
+            return List.of();
+        }
+    }
+
+    @Override
+    public void saveAll(List<TechStack> techStacks) {
+        try {
+            techStacks.forEach(techStackCacheRepository::save);
+        } catch (Exception e) {
+            log.warn("Failed to save to cache", e);
+        }
+    }
+}

--- a/src/test/java/com/example/sideproject/domain/techstack/service/TechStackSourceManagerTest.java
+++ b/src/test/java/com/example/sideproject/domain/techstack/service/TechStackSourceManagerTest.java
@@ -1,0 +1,98 @@
+package com.example.sideproject.domain.techstack.service;
+
+import com.example.sideproject.domain.techstack.dto.TechStackDto;
+import com.example.sideproject.domain.techstack.entity.TechStack;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TechStackSourceManagerTest {
+
+    @Test
+    @DisplayName("캐시에 데이터가 있으면 캐시에서 반환")
+    void should_ReturnFromCache_When_CacheHasData() {
+        // given
+        CacheTechStackStorage cacheStorage = new FakeCacheStorage(
+                List.of(new TechStack(1L, "Java"))
+        );
+        FakePersistentStorage persistentStorage = new FakePersistentStorage(List.of());
+
+        TechStackSourceManager manager = new TechStackSourceManager(cacheStorage, persistentStorage);
+
+        // when
+        List<TechStackDto> result = manager.getTechStackList();
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(persistentStorage.isCalled()).isEqualTo(false);
+    }
+
+    @Test
+    @DisplayName("캐시가 비어있으면 영구 저장소에서 조회하고 캐시에 저장")
+    void should_FetchFromPersistentAndSaveToCache_When_CacheIsEmpty() {
+        // given
+        FakeCacheStorage cacheStorage = new FakeCacheStorage(List.of());
+        FakePersistentStorage persistentStorage = new FakePersistentStorage(
+                List.of(new TechStack(1L, "Python"))
+        );
+
+        TechStackSourceManager manager = new TechStackSourceManager(cacheStorage, persistentStorage);
+
+        // when
+        List<TechStackDto> result = manager.getTechStackList();
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(persistentStorage.isCalled()).isEqualTo(true);
+        assertThat(cacheStorage.getSavedData()).hasSize(1);
+    }
+
+    // Fake 구현체들
+    static class FakeCacheStorage implements CacheTechStackStorage {
+        private List<TechStack> data;
+
+        FakeCacheStorage(List<TechStack> data) {
+            this.data = new ArrayList<>(data);
+        }
+
+        @Override
+        public List<TechStack> findAll() {
+            return data;
+        }
+
+        @Override
+        public void saveAll(List<TechStack> techStacks) {
+            this.data = new ArrayList<>(techStacks);
+        }
+
+        public List<TechStack> getSavedData() {
+            return data;
+        }
+    }
+
+    static class FakePersistentStorage implements PersistentTechStackStorage {
+        private final List<TechStack> data;
+        private boolean isCalled;
+
+        FakePersistentStorage(List<TechStack> data) {
+            this.data = data;
+        }
+
+        @Override
+        public List<TechStack> findAll() {
+            this.isCalled = true;
+            return data;
+        }
+
+        @Override
+        public void saveAll(List<TechStack> techStacks) {}
+
+        public boolean isCalled() {
+            return isCalled;
+        }
+    }
+}


### PR DESCRIPTION
## 내용
- 캐싱 데이터를 가져오다 실패하면 db에서 가져오도록 처리

## 원인
- docker에서 redis는 제대로 실행 되었으나 port를 정상적으로 할당하지 못함
- spring application에서 해당 포트로 접근이 불가하므로, 레디스와의 연결이 실패
- 레디스 연결에 실패했을 때의 방어로직이 없어 db까지 요청이 가지 못하고 GlobalException이 일어남

## 해결
- redis 컨테이너 삭제 후 다시 올림